### PR TITLE
Add translatable functionality to category model

### DIFF
--- a/models/Category.php
+++ b/models/Category.php
@@ -18,6 +18,14 @@ class Category extends Model
      */
     protected $guarded = [];
 
+    /** {@inheritdoc} */
+    public $implement = ['RainLab.Translate.Behaviors.TranslatableModel'];
+
+    /**
+     * @var array Translatable fields
+     */
+    public $translatable = ['name', 'description'];
+
     /**
      * @var array Relations
      */


### PR DESCRIPTION
The portfolio plugin already has translatable functionality, but why not on the categories?

This pull requests gives the category model translatable functionality.
