### PR TITLE
   Added new item component to show single items from the portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,78 @@
 # october-portfolio
 This plugin allows you to show off your past projects. It also can be used for provides services, company values, etc.
 
+## Portfolio component
 The fields included for each showcase item are:
 
 **Field**               | **Description**
 ------------------------|--------------------
 Title                   | Name of the Item
 Category                | Category of the Item
+Slug                    | Slug for the item
 URL (Optional)          | Project/Item URL
 Tags (Optional)         | Tags for the Item
 Description (Optional)  | Description of the Item with rich editor area
 Images (Optional)       | Multiple images related to the item
 
-## Usage
-### Copy the template
+### Usage
+#### Copy the template
 Copy /plugins/arrizalamin/portfolio/components/portfolio/default.htm to your themes partials/portfolio folder. Here is the default template, you can format it any way you like.
 ~~~
 <div class="container">
-    {% for item in __SELF__.portfolio %}
-    <div>
-        {% set image = item.images.first %}
-        <a href="{{ item.url }}">
-            <img src="{{ image.path }}" class="img-responsive" alt="{{ image.title }}">
-        </a>
-    </div>
-    <h2 class="text-center">{{ item.title }}</h2>
-    <div class="text-center">
-        {% for tag in item.tags %}
-            <span class="label label-default">{{ tag.name }}</span>
+    <div class="row">
+        {% for item in __SELF__.portfolio %}
+        <div class="col-lg-4">
+            {% if item.images|length > 0 %}
+            <div>
+                {% set image = item.images.first %}
+                <a href="{{ item.pageUrl }}">
+                    <img src="{{ image.path }}" class="img-responsive" alt="{{ image.title }}">
+                </a>
+            </div>
+            {% endif %}
+            <a href="{{ item.pageUrl }}"><h2>{{ item.title }}</h2></a>
+            <small>posted {{ item.created_at|date('j m Y') }} in <a href="{{ item.category.pageUrl }}">{{ item.category.name }}</a></small>
+            {% if item.tags|length > 0 %}
+            <div>
+                {% for tag in item.tags %}
+                <a href="{{ tag.pageUrl }}"><span class="label label-primary">{{ tag.name }}</span></a>
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% if item.description %}
+            <p>
+                {{ item.description|raw }}
+            </p>
+            {% endif %}
+        </div>
         {% endfor %}
     </div>
-    <div class="text-center">
-        {{ item.description|raw }}
-    </div>
-    {% endfor %}
 
     {% if __SELF__.portfolio.lastPage > 1 %}
-    <ul class="pagination">
-        {% if __SELF__.portfolio.currentPage > 1 %}
-        <li><a href="{{ this.page.baseFileName|page({ page: (__SELF__.portfolio.currentPage - 1) }) }}">&larr; Prev</a></li>
-        {% endif %}
+    <div class="row">
+        <div class="col-sm-12">
+            <ul class="pagination">
+                {% if __SELF__.portfolio.currentPage > 1 %}
+                <li><a href="{{ this.page.baseFileName|page({ page: (__SELF__.portfolio.currentPage - 1) }) }}">&larr; Prev</a></li>
+                {% endif %}
 
-        {% for page in 1..__SELF__.portfolio.lastPage %}
-        <li class="{{ __SELF__.portfolio.currentPage == page ? 'active' : null }}">
-            <a href="{{ this.page.baseFileName|page({ page: page }) }}">{{ page }}</a>
-        </li>
-        {% endfor %}
+                {% for page in 1..__SELF__.portfolio.lastPage %}
+                <li class="{{ __SELF__.portfolio.currentPage == page ? 'active' : null }}">
+                    <a href="{{ this.page.baseFileName|page({ page: page }) }}">{{ page }}</a>
+                </li>
+                {% endfor %}
 
-        {% if __SELF__.portfolio.lastPage > __SELF__.portfolio.currentPage %}
-        <li><a href="{{ this.page.baseFileName|page({ page: (__SELF__.portfolio.currentPage + 1) }) }}">Next &rarr;</a></li>
-        {% endif %}
-    </ul>
+                {% if __SELF__.portfolio.lastPage > __SELF__.portfolio.currentPage %}
+                <li><a href="{{ this.page.baseFileName|page({ page: (__SELF__.portfolio.currentPage + 1) }) }}">Next &rarr;</a></li>
+                {% endif %}
+            </ul>
+        </div>
+    </div>
     {% endif %}
 </div>
 ~~~
 
-### Portfolio component
+#### add the component
 Now you can embed portfolio in your pages. Just use the portfolio component in your page, select category of your portfolio and place `{% component 'portfolio' %}` anywhere you like.
 
 Simple use case:
@@ -71,28 +88,92 @@ pageNumber = {{ :page }}
 {% component 'portfolio' %}
 ~~~
 
-### Tags
-The default usage of tags is implemented as static tags. The tags are displayed with the item but are not clickable.
-The tags can made clickable to have a more dynamic portfolio. Now tags can be clicked and a page with all items with the tag are displayed.
-
-This can be achieved by adding the a-tag to each tag. See this example:
+#### Categories
+The categories of an item of a portfolio are highlighted as hyperlink by default. To use this functionality you'll need to add a page which can show all items of the selected category.
+The basic code needed is:
 ~~~
-{% for tag in item.tags %}
-    <a href="\portfolio\tags\{{ tag.name}}"><span class="label label-default">{{ tag.name }}</span></a>
-{% endfor %}
-~~~
-
-An extra page should be created to have a landing page for the link.
-In the CMS the following page needs to be created to get this working:
-~~~
-title = "Items by tag"
-url = "/portfolio/:selected_tag/:page?"
+title = "Portfolio category item list"
+url = "/portfolio/category/:selected_cat/:page?"
 
 [portfolio]
-category = "0"
-itemsPerPage = "5"
-selectedTag = {{ :selected_tag }}
-pageNumber = {{ :page }}
+category = 1
+itemsPerPage = 6
+order = "asc"
+pageNumber = "{{ :page }}"
+selectedCat = "{{ :selected_cat }}"
 ==
 {% component 'portfolio' %}
 ~~~
+
+
+#### Tags
+Like for the categories you'll also need to add a page for the tags. Tags can be clicked when the portfolio is viewed. When clicked this page will be opened and an overview of all items with the selected tag will be displayed.
+In the CMS the following page needs to be created to get this working:
+~~~
+title = "Portfolio items by tag"
+url = "/portfolio/tags/:selected_tag/:page?"
+
+[portfolio]
+itemsPerPage = 6
+order = "asc"
+pageNumber = "{{ :page }}"
+selectedTag = "{{ :selected_tag }}"
+==
+{% component 'portfolio' %}
+~~~
+
+## Item component
+The item component is to show off single items from the portfolio.
+It is also used to show your items when clicking the items displayed by the portfolio component.
+
+### Usage
+#### Copy the template
+Copy /plugins/arrizalamin/portfolio/components/item/default.htm to your themes partials/item folder. Here is the default template, you can format it any way you like.
+~~~
+{% set item = __SELF__.item %}
+<div class="container">
+    <div class="row">
+        <div class="col-lg-6">
+            {% for image in item.images %}
+            <div class="col-sm-6">
+                <img src="{{ image.path }}" class="img-responsive" alt="{{ image.title }}">
+            </div>
+            {% endfor %}
+        </div>
+        <div class="col-lg-6">
+            <h1>Portfolio Item {{ item.id }}</h1>
+            <h2>{{ item.title }}</h2>
+            <small>posted {{ item.created_at|date('j m Y') }} in <a href="{{ item.category.pageUrl }}">{{ item.category.name }}</a></small>
+            <div>
+                {% for tag in item.tags %}
+                <a href="\portfolio\tags\{{ tag.name}}"><span class="label label-default">{{ tag.name }}</span></a>
+                {% endfor %}
+            </div>
+            <p>{{ item.description|raw }}</p>
+            {% if item.url %}
+                <a href="{{ item.url }}" class="btn btn-default" target="_blank">view project</a>
+            {% endif %}
+        </div>
+    </div>
+</div>
+~~~
+
+### Add the component
+To be able to click and follow the headers of an item in the portfolio overview created by the portfolio component you'll need to add a page with the item component.
+A simple example:
+~~~
+title = "Portfolio Item"
+url = "/portfolio/item/:item_slug"
+
+[item]
+itemSlug = "{{ :item_slug }}"
+==
+{% component 'item' %}
+~~~
+
+Another way to use the item component is to show single portfolio items in any page. Just add the item component in your page, select the item from your portfolio and place `{% component 'item' %}` anywhere you like.
+Use the same example as above with any URL you like to use and select from the item component the correct 'Item to show' and save the page.
+
+## Component Links
+Each of the components uses a links dropdown menu to select the landing pages for *categories*, *tags* and *items*.
+These values need to be set to allow the components to create the correct hyperlinks for the heading item links, category links and tags links.

--- a/components/Item.php
+++ b/components/Item.php
@@ -1,0 +1,165 @@
+<?php namespace ArrizalAmin\Portfolio\Components;
+
+use Cms\Classes\ComponentBase;
+use Cms\Classes\Page;
+use Lang;
+use ArrizalAmin\Portfolio\Models\Item as PortfolioItem;
+
+class Item extends ComponentBase
+{
+    /**
+     * Value holds the selected item to display
+     * @var
+     */
+    public $item;
+
+    /**
+     * Reference to the page where tagged items are displayed
+     *
+     * @var String;
+     */
+    public $tagListPage;
+
+    /**
+     * Reference to the page where items of a category are displayed
+     *
+     * @var
+     */
+    public $catListPage;
+
+
+    public function componentDetails()
+    {
+        return [
+            'name'        => 'arrizalamin.portfolio::lang.components.item.name',
+            'description' => 'arrizalamin.portfolio::lang.components.item.description'
+        ];
+    }
+
+    public function defineProperties()
+    {
+        return [
+            'item' => [
+                'title'       => 'arrizalamin.portfolio::lang.components.item.properties.item.title',
+                'description' => 'arrizalamin.portfolio::lang.components.item.properties.item.description',
+                'type'        => 'dropdown',
+                'default'     => '1',
+            ],
+            'itemSlug' => [
+                'title'       => 'arrizalamin.portfolio::lang.components.item.properties.itemSlug.title',
+                'description' => 'arrizalamin.portfolio::lang.components.item.properties.itemSlug.description',
+                'type'        => 'string',
+                'default'     => '{{ :item_slug }}',
+                'group'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.group.advanced',
+            ],
+            'catListPage' => [
+                'title'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.catListPage.title',
+                'description' => 'arrizalamin.portfolio::lang.components.portfolio.properties.catListPage.description',
+                'type'        => 'dropdown',
+                'default'     => 'portfolio/category',
+                'group'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.group.links',
+            ],
+            'tagListPage' => [
+                'title'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.tagListPage.title',
+                'description' => 'arrizalamin.portfolio::lang.components.portfolio.properties.tagListPage.description',
+                'type'        => 'dropdown',
+                'default'     => 'portfolio/tag',
+                'group'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.group.links',
+            ],
+        ];
+    }
+
+    /**
+     * Get options for the item dropdown
+     *
+     * @return mixed
+     */
+    public function getItemOptions()
+    {
+        $categories = PortfolioItem::lists('title', 'slug');
+        $categories[0] = Lang::get('arrizalamin.portfolio::lang.components.item.properties.item.none');
+        return $categories;
+    }
+
+    /**
+     * Get options for the dropdown where the link to the tag list page can be selected
+     *
+     * @return mixed
+     */
+    public function getTagListPageOptions()
+    {
+        return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
+    }
+
+    /**
+     * Get options for the dropdown where the link to the category list page can be selected
+     *
+     * @return mixed
+     */
+    public function getCatListPageOptions()
+    {
+        return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
+    }
+
+    public function onRun()
+    {
+        // Page links
+        $this->tagListPage = $this->page['tagListPage'] = $this->property('tagListPage');
+        $this->catListPage = $this->page['catListPage'] = $this->property('catListPage');
+
+        // find the correct property to select the items with
+        $object = null;
+        if($this->property('itemSlug') != null && $this->property('itemSlug') != 'default'){
+            $object = $this->loadItemBySlug($this->property('itemSlug'));
+        }elseif ($this->property('item') != null && $this->property('item') != 'None') {
+            $object = $this->loadItemBySlug($this->property('item'));
+        }
+
+        // check if a valid object has been created
+        if( !$object ){
+            // todo : throw error
+            $this->item = null;
+        }else{
+            // show the items in the portfolio
+            $this->item = $object;
+        }
+
+        // Add url helper to the items
+        if($this->item != null) {
+            $this->item = $this->updatePageUrls($this->item);
+        }
+    }
+
+    /**
+     * Load the selected item by its slug
+     *
+     * @param $selectedItem
+     * @return mixed
+     */
+    protected function loadItemBySlug($selectedItem)
+    {
+        $item = PortfolioItem::where('slug', '=', $selectedItem)->first();
+        return $item;
+    }
+
+    /**
+     * Add PageUrl helpers to all items which can be linked to a
+     * dedicated page to display the item.
+     *
+     * @param $item
+     * @return mixed
+     */
+    protected function updatePageUrls($item)
+    {
+        // add to tags
+        $item->tags->each(function ($tag) {
+            $tag->setPageUrl($this->tagListPage, $this->controller);
+        });
+
+        // add to category
+        $item->category->setPageUrl($this->catListPage, $this->controller);
+
+        return $item;
+    }
+
+}

--- a/components/Portfolio.php
+++ b/components/Portfolio.php
@@ -4,12 +4,44 @@ use Cms\Classes\ComponentBase;
 use ArrizalAmin\Portfolio\Models\Item;
 use ArrizalAmin\Portfolio\Models\Category;
 use ArrizalAmin\Portfolio\Models\Tag;
+use Cms\Classes\Page;
 use Lang;
 
 class Portfolio extends ComponentBase
 {
+    /**
+     * Collection of the portfolio items to display
+     *
+     * @var Collection
+     */
     public $portfolio;
 
+    /**
+     * Reference to the item page to link items to
+     *
+     * @var String
+     */
+    public $itemPage;
+
+    /**
+     * Reference to the page where tagged items are displayed
+     *
+     * @var String;
+     */
+    public $tagListPage;
+
+    /**
+     * Reference to the page where items of a category are displayed
+     *
+     * @var
+     */
+    public $catListPage;
+
+    /**
+     * Component Details
+     *
+     * @return array
+     */
     public function componentDetails()
     {
         return [
@@ -18,6 +50,11 @@ class Portfolio extends ComponentBase
         ];
     }
 
+    /**
+     * Define component properties
+     *
+     * @return array
+     */
     public function defineProperties()
     {
         return [
@@ -51,12 +88,45 @@ class Portfolio extends ComponentBase
                 'title' => 'arrizalamin.portfolio::lang.components.portfolio.properties.selectedTag.title',
                 'description' => 'arrizalamin.portfolio::lang.components.portfolio.properties.selectedTag.description',
                 'type' => 'string',
-                'group' => 'arrizalamin.portfolio::lang.components.portfolio.properties.group.advanced',
-                'default' => '{{ :selected_tag }}'
-            ]
+                'default' => '{{ :selected_tag }}',
+                'group' => 'arrizalamin.portfolio::lang.components.portfolio.properties.group.advanced'
+            ],
+            'selectedCat' => [
+                'title' => 'arrizalamin.portfolio::lang.components.portfolio.properties.selectedCat.title',
+                'description' => 'arrizalamin.portfolio::lang.components.portfolio.properties.selectedCat.description',
+                'type' => 'string',
+                'default' => '{{ :selected_cat }}',
+                'group' => 'arrizalamin.portfolio::lang.components.portfolio.properties.group.advanced'
+            ],
+            'catListPage' => [
+                'title'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.catListPage.title',
+                'description' => 'arrizalamin.portfolio::lang.components.portfolio.properties.catListPage.description',
+                'type'        => 'dropdown',
+                'default'     => 'portfolio/category',
+                'group'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.group.links',
+            ],
+            'itemPage' => [
+                'title'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.itemPage.title',
+                'description' => 'arrizalamin.portfolio::lang.components.portfolio.properties.itemPage.description',
+                'type'        => 'dropdown',
+                'default'     => 'portfolio/item',
+                'group'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.group.links',
+            ],
+            'tagListPage' => [
+                'title'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.tagListPage.title',
+                'description' => 'arrizalamin.portfolio::lang.components.portfolio.properties.tagListPage.description',
+                'type'        => 'dropdown',
+                'default'     => 'portfolio/tag',
+                'group'       => 'arrizalamin.portfolio::lang.components.portfolio.properties.group.links',
+            ],
         ];
     }
 
+    /**
+     * Get options for the category dropdown
+     *
+     * @return mixed
+     */
     public function getCategoryOptions()
     {
         $categories = Category::lists('name', 'id');
@@ -64,6 +134,11 @@ class Portfolio extends ComponentBase
         return $categories;
     }
 
+    /**
+     * Get options for the order dropdown
+     *
+     * @return array
+     */
     public function getOrderOptions()
     {
         return [
@@ -72,13 +147,53 @@ class Portfolio extends ComponentBase
         ];
     }
 
+    /**
+     * Get options for the dropdown where the link to the item page can be selected
+     *
+     * @return mixed
+     */
+    public function getItemPageOptions()
+    {
+        return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
+    }
+
+    /**
+     * Get options for the dropdown where the link to the tag list page can be selected
+     *
+     * @return mixed
+     */
+    public function getTagListPageOptions()
+    {
+        return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
+    }
+
+    /**
+     * Get options for the dropdown where the link to the category list page can be selected
+     *
+     * @return mixed
+     */
+    public function getCatListPageOptions()
+    {
+        return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
+    }
+
+    /**
+     * When running this component, load all items based on the selections.
+     */
     public function onRun()
     {
+        // Page links
+        $this->itemPage = $this->page['itemPage'] = $this->property('itemPage');
+        $this->tagListPage = $this->page['tagListPage'] = $this->property('tagListPage');
+        $this->catListPage = $this->page['catListPage'] = $this->property('catListPage');
+
         // find the correct property to select the items with
         $object = null;
         if($this->property('selectedTag') != null){
             $object = $this->loadItemsByTag($this->property('selectedTag'));
-        }elseif($this->property('category') != null){
+        }elseif($this->property('selectedCat') != null){
+            $object = $this->loadItemsByCategory($this->property('selectedCat'), true);
+        }elseif($this->property('category') != null) {
             $object = $this->loadItemsByCategory($this->property('category'));
         }
 
@@ -91,12 +206,24 @@ class Portfolio extends ComponentBase
             $this->portfolio = $object->items()
                 ->orderBy('created_at', $this->property('order'))->paginate($this->property('itemsPerPage'), $this->property('pageNumber'));
         }
+
+        // Add url helper to the items
+        if($this->portfolio != null) {
+            $this->portfolio = $this->updatePageUrls($this->portfolio);
+        }
     }
 
-    protected function loadItemsByCategory($selectedCategory, $byName = false)
+    /**
+     * Get the selected category object for further processing.
+     *
+     * @param $selectedCategory
+     * @param bool|false $bySlug
+     * @return mixed
+     */
+    protected function loadItemsByCategory($selectedCategory, $bySlug = false)
     {
-        if($byName){
-            $category = Category::where('name', '=', $selectedCategory)->first();
+        if($bySlug){
+            $category = Category::where('slug', '=', $selectedCategory)->first();
         }else{
             $category = Category::find($selectedCategory);
         }
@@ -104,10 +231,39 @@ class Portfolio extends ComponentBase
         return $category;
     }
 
+    /**
+     * Get the selected tag object for processing
+     *
+     * @param $selectedTag
+     * @return mixed
+     */
     protected function loadItemsByTag($selectedTag)
     {
         $tag = Tag::where('name', '=', $selectedTag)->first();
         return $tag;
     }
 
+    /**
+     * Add PageUrl helpers to all items which can be linked to a
+     * dedicated page to display the item.
+     *
+     * @param $items
+     * @return mixed
+     */
+    protected function updatePageUrls($items)
+    {
+        //Add a "url" helper attribute for linking to each item
+        $items->each(function($item)
+        {
+            $item->setPageUrl($this->itemPage, $this->controller);
+
+            $item->tags->each(function ($tag) {
+                $tag->setPageUrl($this->tagListPage, $this->controller);
+            });
+
+            $item->category->setPageUrl($this->catListPage, $this->controller);
+        });
+
+        return $items;
+    }
 }

--- a/components/item/default.htm
+++ b/components/item/default.htm
@@ -1,0 +1,26 @@
+{% set item = __SELF__.item %}
+<div class="container">
+    <div class="row">
+        <div class="col-lg-6">
+            {% for image in item.images %}
+            <div class="col-sm-6">
+                <img src="{{ image.path }}" class="img-responsive" alt="{{ image.title }}">
+            </div>
+            {% endfor %}
+        </div>
+        <div class="col-lg-6">
+            <h1>Portfolio Item {{ item.id }}</h1>
+            <h2>{{ item.title }}</h2>
+            <small>posted {{ item.created_at|date('j m Y') }} in <a href="{{ item.category.pageUrl }}">{{ item.category.name }}</a></small>
+            <div>
+                {% for tag in item.tags %}
+                <a href="\portfolio\tags\{{ tag.name}}"><span class="label label-default">{{ tag.name }}</span></a>
+                {% endfor %}
+            </div>
+            <p>{{ item.description|raw }}</p>
+            {% if item.url %}
+                <a href="{{ item.url }}" class="btn btn-default" target="_blank">view project</a>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/components/portfolio/default.htm
+++ b/components/portfolio/default.htm
@@ -1,45 +1,53 @@
 <div class="container">
-    {% for item in __SELF__.portfolio %}
-    {% if item.images|length > 0 %}
-    <div>
-        {% set image = item.images.first %}
-        <a href="{{ item.url }}">
-            <img src="{{ image.path }}" class="img-responsive" alt="{{ image.title }}">
-        </a>
-    </div>
-    {% endif %}
-    <h2 class="text-center">{{ item.title }}</h2>
-    {% if item.tags|length > 0 %}
-    <div class="text-center">
-        {% for tag in item.tags %}
-        <a href="\portfolio\tags\{{ tag.name}}"><span class="label label-default">{{ tag.name }}</span></a>
+    <div class="row">
+        {% for item in __SELF__.portfolio %}
+        <div class="col-lg-4">
+            {% if item.images|length > 0 %}
+            <div>
+                {% set image = item.images.first %}
+                <a href="{{ item.pageUrl }}">
+                    <img src="{{ image.path }}" class="img-responsive" alt="{{ image.title }}">
+                </a>
+            </div>
+            {% endif %}
+            <a href="{{ item.pageUrl }}"><h2>{{ item.title }}</h2></a>
+            <small>posted {{ item.created_at|date('j m Y') }} in <a href="{{ item.category.pageUrl }}">{{ item.category.name }}</a></small>
+            {% if item.tags|length > 0 %}
+            <div>
+                {% for tag in item.tags %}
+                <a href="{{ tag.pageUrl }}"><span class="label label-primary">{{ tag.name }}</span></a>
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% if item.description %}
+            <p>
+                {{ item.description|raw }}
+            </p>
+            {% endif %}
+        </div>
         {% endfor %}
     </div>
-    {% endif %}
-    {% if item.description %}
-    <div class="text-center">
-        {{ item.description|raw }}
-    </div>
-    {% endif %}
-    {% endfor %}
 
     {% if __SELF__.portfolio.lastPage > 1 %}
-    <ul class="pagination">
-        {% if __SELF__.portfolio.currentPage > 1 %}
-        <li><a href="{{ this.page.baseFileName|page({ page: (__SELF__.portfolio.currentPage - 1) }) }}">&larr; Prev</a></li>
-        {% endif %}
+    <div class="row">
+        <div class="col-sm-12">
+            <ul class="pagination">
+                {% if __SELF__.portfolio.currentPage > 1 %}
+                <li><a href="{{ this.page.baseFileName|page({ page: (__SELF__.portfolio.currentPage - 1) }) }}">&larr; Prev</a></li>
+                {% endif %}
 
-        {% for page in 1..__SELF__.portfolio.lastPage %}
-        <li class="{{ __SELF__.portfolio.currentPage == page ? 'active' : null }}">
-            <a href="{{ this.page.baseFileName|page({ page: page }) }}">{{ page }}</a>
-        </li>
-        {% endfor %}
+                {% for page in 1..__SELF__.portfolio.lastPage %}
+                <li class="{{ __SELF__.portfolio.currentPage == page ? 'active' : null }}">
+                    <a href="{{ this.page.baseFileName|page({ page: page }) }}">{{ page }}</a>
+                </li>
+                {% endfor %}
 
-        {% if __SELF__.portfolio.lastPage > __SELF__.portfolio.currentPage %}
-        <li><a href="{{ this.page.baseFileName|page({ page: (__SELF__.portfolio.currentPage + 1) }) }}">Next &rarr;</a></li>
-        {% endif %}
-    </ul>
+                {% if __SELF__.portfolio.lastPage > __SELF__.portfolio.currentPage %}
+                <li><a href="{{ this.page.baseFileName|page({ page: (__SELF__.portfolio.currentPage + 1) }) }}">Next &rarr;</a></li>
+                {% endif %}
+            </ul>
+        </div>
+    </div>
     {% endif %}
-
 </div>
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -2,7 +2,7 @@
 
 return [
     'plugin' => [
-        'name' => 'Portfolio',
+        'name' => 'Portfolio list',
         'description' => 'A plugin that allows you to show off your past projects.',
     ],
     'navigation' => [
@@ -27,10 +27,6 @@ return [
                     'placeholder' => 'Select Category',
                     'all' => 'All'
                 ],
-                'selectedTag' => [
-                    'title' => 'Selected Tag',
-                    'description' => 'This value can be changed depending on the identifier used in the URL of this page. See the manual for this plugin for more information.'
-                ],
                 'pageNumber' => [
                     'title' => 'Page Number',
                     'description' => 'This value is used to determine what page the user is on.'
@@ -46,10 +42,45 @@ return [
                     'descending' => 'Descending'
                 ],
                 'group' => [
-                    'advanced' => 'Advanced'
-                ]
-
-            ]
+                    'advanced' => 'Advanced',
+                    'links' => 'Links'
+                ],
+                'selectedTag' => [
+                    'title' => 'Selected tag',
+                    'description' => 'Don\'t change this value (default: {{ :selected_tag }})'
+                ],
+                'selectedCat' => [
+                    'title' => 'Selected category',
+                    'description' => 'Don\'t change this value (default: {{ :selected_cat }})'
+                ],
+                'itemPage' => [
+                    'title' => 'Item page',
+                    'description' => 'Page where portfolio items can be displayed.'
+                ],
+                'tagListPage' => [
+                    'title' => 'Tag list page',
+                    'description' => 'Page where portfolio items with matching tag are listed.'
+                ],
+                'catListPage' => [
+                    'title' => 'Category page',
+                    'description' => 'Page where portfolio items of the selected category are listed.'
+                ],
+            ],
+        ],
+        'item' => [
+            'name' => 'Item',
+            'description' => 'Display a single item from the portfolio collection.',
+            'properties' => [
+                'item' => [
+                    'title' => 'Item to show',
+                    'description' => 'Select a item to show. Will be overridden by URL item selection.',
+                    'none' => 'None',
+                ],
+                'itemSlug' => [
+                    'title' => 'Item slug',
+                    'description' => 'Item slug URL identifier'
+                ],
+            ],
         ],
     ],
     'controller' => [
@@ -130,6 +161,7 @@ return [
         'item' => [
             'title' => 'Title',
             'category' => 'Category',
+            'slug' => 'Slug',
             'tags' => 'Tags',
             'description' => 'Description',
             'images' => 'Images',
@@ -137,6 +169,7 @@ return [
         ],
         'category' => [
             'name' => 'Name',
+            'slug' => 'Slug',
             'description' => 'Description'
         ],
         'tag' => [

--- a/models/Category.php
+++ b/models/Category.php
@@ -33,4 +33,20 @@ class Category extends Model
         'items' => ['ArrizalAmin\Portfolio\Models\Item']
     ];
 
+    /**
+     * Set the PageUrl parameter to link the correct page
+     *
+     * @param $pageName
+     * @param $controller
+     * @return mixed
+     */
+    public function setPageUrl($pageName, $controller)
+    {
+        $params = [
+            'selected_cat' => $this->slug,
+        ];
+
+        return $this->pageUrl = $controller->pageUrl($pageName, $params);
+    }
+
 }

--- a/models/Item.php
+++ b/models/Item.php
@@ -59,7 +59,24 @@ class Item extends Model
         $this->tags = $tags;
     }
 
-     /**
+    /**
+     * Set the PageUrl parameter to link the correct page
+     *
+     * @param $pageName
+     * @param $controller
+     * @return mixed
+     */
+    public function setPageUrl($pageName, $controller)
+    {
+        $params = [
+            'item_slug' => $this->slug,
+        ];
+
+        return $this->pageUrl = $controller->pageUrl($pageName, $params);
+    }
+
+
+    /**
      * Add translation support to this model, if available.
      * @return void
      */

--- a/models/Tag.php
+++ b/models/Tag.php
@@ -60,4 +60,21 @@ class Tag extends Model
         $this->attributes['name'] = strtolower($value);
     }
 
+    /**
+     * Set the PageUrl parameter to link the correct page
+     *
+     * @param $pageName
+     * @param $controller
+     * @return mixed
+     */
+    public function setPageUrl($pageName, $controller)
+    {
+        $params = [
+            'selected_tag' => $this->name,
+        ];
+
+        return $this->pageUrl = $controller->pageUrl($pageName, $params);
+    }
+
+
 }

--- a/models/category/columns.yaml
+++ b/models/category/columns.yaml
@@ -3,9 +3,6 @@
 # ===================================
 
 columns:
-    id:
-        label: arrizalamin.portfolio::lang.columns.category.id
-        searchable: true
     name:
         label: arrizalamin.portfolio::lang.columns.category.name
         searchable: true

--- a/models/category/fields.yaml
+++ b/models/category/fields.yaml
@@ -5,7 +5,14 @@
 fields:
     name:
         label: arrizalamin.portfolio::lang.fields.category.name
+        span: left
         searchable: true
+    slug:
+        label: arrizalamin.portfolio::lang.fields.category.slug
+        span: right
+        preset:
+            field: name
+            type: slug
     description:
         label: arrizalamin.portfolio::lang.fields.category.description
         type: textarea

--- a/models/item/columns.yaml
+++ b/models/item/columns.yaml
@@ -3,9 +3,6 @@
 # ===================================
 
 columns:
-    id:
-        label: arrizalamin.portfolio::lang.columns.item.id
-        searchable: true
     title:
         label: arrizalamin.portfolio::lang.columns.item.title
         searchable: true

--- a/models/item/fields.yaml
+++ b/models/item/fields.yaml
@@ -6,18 +6,23 @@ fields:
     title:
         label: arrizalamin.portfolio::lang.fields.item.title
         span: left
+    slug:
+        label: arrizalamin.portfolio::lang.fields.item.slug
+        span: right
+        preset:
+            field: title
+            type: slug
     category:
         label: arrizalamin.portfolio::lang.fields.item.category
-        span: right
+        span: left
         type: relation
         nameFrom: name
     url:
         label: arrizalamin.portfolio::lang.fields.item.url
         type: text
-        span: left
+        span: right
     tagbox:
         label: arrizalamin.portfolio::lang.fields.item.tags
-        span: right
         type: owl-tagbox
         nameFrom: name
         slugify: true

--- a/updates/seed_example_data.php
+++ b/updates/seed_example_data.php
@@ -1,0 +1,67 @@
+<?php namespace ArrizalAmin\Portfolio\Updates;
+
+use ArrizalAmin\Portfolio\Models\Category;
+use ArrizalAmin\Portfolio\Models\Item;
+use ArrizalAmin\Portfolio\Models\Tag;
+use October\Rain\Database\Updates\Seeder;
+
+class SeedExampleData extends Seeder
+{
+
+    public function run()
+    {
+        /**
+         * Add example categories
+         */
+        $ec = Category::create([
+            'name' => 'Examples',
+            'slug' => 'examples'
+        ]);
+
+        /**
+         * Add example tags
+         */
+        $t1 = Tag::create([
+            'name' => 'one',
+        ]);
+        $t2 = Tag::create([
+            'name' => 'two',
+        ]);
+        $t3 = Tag::create([
+            'name' => 'three',
+        ]);
+
+        /**
+         * Add example items
+         */
+        $i1 = Item::create([
+            'category_id' => $ec->id,
+            'title' => 'Proactively disseminate',
+            'slug' => 'proactively',
+            'description' => 'Proactively disseminate parallel markets after open-source e-services. Quickly administrate goal-oriented sources through turnkey human capital. Intrinsicly transition installed base schemas with reliable resources. Proactively leverage other\'s compelling mindshare with interoperable applications. Holisticly aggregate transparent metrics through just in time value. Conveniently target pandemic paradigms through leading-edge intellectual capital. Authoritatively create next-generation products rather than reliable platforms. Dramatically predominate robust materials rather than principle-centered innovation. Quickly simplify market positioning niches through equity invested outsourcing. Intrinsicly integrate progressive niche markets.',
+        ]);
+
+        $i1->tags()->attach($t1->id);
+
+        $i2 = Item::create([
+            'category_id' => $ec->id,
+            'title' => 'Intrinsicly integrate',
+            'slug' => 'intrinsicly',
+            'description' => 'Intrinsicly integrate future-proof e-tailers whereas high-quality users. Conveniently procrastinate world-class e-business vis-a-vis stand-alone technology. Competently streamline bleeding-edge process improvements after user friendly e-business. Dynamically myocardinate sticky results and visionary schemas. Assertively streamline standardized materials with distributed total linkage. Distinctively envisioneer multimedia based mindshare via extensive core competencies. Conveniently deliver market positioning initiatives before sustainable convergence. Collaboratively myocardinate stand-alone results for exceptional best practices. Completely initiate global mindshare with frictionless ideas. Synergistically reintermediate wireless intellectual capital rather than reliable.',
+        ]);
+
+        $i2->tags()->attach([$t1->id, $t2->id]);
+
+        $i3 = Item::create([
+            'category_id' => $ec->id,
+            'title' => 'Collaboratively initiate',
+            'slug' => 'collaboratively',
+            'description' => 'Collaboratively initiate top-line catalysts for change via process-centric growth strategies. Monotonectally leverage existing functional initiatives via enabled process improvements. Synergistically benchmark synergistic supply chains and economically sound supply chains. Assertively productivate front-end outsourcing and next-generation experiences. Progressively myocardinate intuitive scenarios with optimal e-services. Holisticly initiate pandemic platforms via granular human capital. Monotonectally promote diverse web-readiness without competitive niche markets. Enthusiastically evisculate enterprise-wide customer service with business vortals. Synergistically cultivate ethical information with bleeding-edge products. Globally evisculate functional networks.',
+        ]);
+
+        $i3->tags()->attach([$t1->id, $t2->id, $t3->id]);
+
+        //TODO: find a way to attach sample images to the items.
+    }
+
+}

--- a/updates/update_tables_with_slugs.php
+++ b/updates/update_tables_with_slugs.php
@@ -1,0 +1,35 @@
+<?php namespace ArrizalAmin\Portfolio\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class UpdateTablesWithSlugs extends Migration
+{
+
+    public function up()
+    {
+        Schema::table('arrizalamin_portfolio_items', function($table)
+        {
+            $table->string('slug')->index();
+        });
+
+        Schema::table('arrizalamin_portfolio_categories', function($table)
+        {
+            $table->string('slug')->index();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('arrizalamin_portfolio_items', function($table)
+        {
+            $table->dropColumn('slug');
+        });
+
+        Schema::table('arrizalamin_portfolio_categories', function($table)
+        {
+            $table->dropColumn('slug');
+        });
+    }
+
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -18,3 +18,10 @@
 1.3.1:
     - Added translatable functionality to category model
     - Fixed requirement of Rainlab.Translate plugin
+1.4.0:
+    - Created Item component to show portfolio items
+    - Added slug fields to items and categories
+    - Added link functionality to categories
+    - Seed example data
+    - update_tables_with_slugs.php
+    - seed_example_data.php


### PR DESCRIPTION
Added functionality to create hyperlinks to follow headings of items shown in the overview to directly navigate to the portfolio item.
Included the function to follow categories and show all items within the selected category. This functionality is similar to the hyperlinks in tags from the previous update.

```
- Created Item component to show portfolio items
- Added slug fields to items and categories
- Added link functionality to categories
- Seed example data
```
